### PR TITLE
Bump Node and Npm to the latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains docker images for the Visual Studio Team Services (VSTS
 
 * ubuntu-16.04-php-node
 	* PHP 7.2 with composer
-	* Node.js 9.9.0 with npm 5.6.0
+	* Node.js 10.0 with npm 6.0
 	* Grunt-Cli
 * windowsservercore-1709
 	* .NET Framework 4.7.1

--- a/ubuntu/16.04/php/Dockerfile
+++ b/ubuntu/16.04/php/Dockerfile
@@ -43,7 +43,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');"
 
 # Node
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - && apt-get install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
 
 # Npm
-RUN npm install -g grunt-cli
+RUN npm install -g npm@6.0.0 grunt-cli


### PR DESCRIPTION
This PR bumps the Node to version 10, and upgrades npm to the latest, which at the moment is 6. 