### PR TITLE
Include code to set windows culture and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ docker run \
     -it \
     emishealth/vsts-agent-docker:<tag>
 ```
+
+You can use the additional parameter ``` -e SERVER_LANGUAGE=en-GB ``` on the windows image to change the language and culture of the container

--- a/windows/servercore/1709/Start.ps1
+++ b/windows/servercore/1709/Start.ps1
@@ -40,6 +40,24 @@ if($env:VSTS_POOL -eq $null)
     $env:VSTS_POOL = "Default"
 }
 
+if($env:SERVER_LANGUAGE -eq $null)
+{
+    $env:SERVER_LANGUAGE = "en-US";
+}
+
+# Import 'International' module to Powershell session
+Import-Module International
+$culture = New-Object System.Globalization.CultureInfo($input);
+
+Write-Host "Culture found";
+Write-Host $culture.CompareInfo;
+
+# Set regional format - this applies to all users
+Set-Culture $culture;
+
+$UserLanguageList = New-WinUserLanguageList -Language $env:SERVER_LANGUAGE;
+Set-WinUserLanguageList -LanguageList $UserLanguageList -Force;
+
 $useragent = 'vsts-windowscontainer'
 $creds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($("user:$env:VSTS_TOKEN")))
 $encodedAuthValue = "Basic $creds"

--- a/windows/servercore/1709/Start.ps1
+++ b/windows/servercore/1709/Start.ps1
@@ -50,7 +50,6 @@ Import-Module International
 $culture = New-Object System.Globalization.CultureInfo($input);
 
 Write-Host "Culture found";
-Write-Host $culture.CompareInfo;
 
 # Set regional format - this applies to all users
 Set-Culture $culture;


### PR DESCRIPTION
Include code to set windows culture and language

Included as some unit tests can be culture specific, causing them to fail if run on the wrong agent culture